### PR TITLE
Add sort countries by name after fetch

### DIFF
--- a/src/lib/fetchCountries.ts
+++ b/src/lib/fetchCountries.ts
@@ -1,6 +1,10 @@
+import { Country } from "@/types/country"
 export async function fetchCountries() {
     const res = await fetch("https://restcountries.com/v3.1/all");
     if (!res.ok) throw new Error("Failed to fetch countries");
 
-    return res.json();
+    const data = await res.json();
+
+    return data.sort((a: Country, b: Country) =>
+        a.name.common.localeCompare(b.name.common))
 }


### PR DESCRIPTION
Description:

 I added alphabetical sorting of countries after fetching them from the REST Countries API. The goal is to improve user experience for the dropdown menu when selecting country. 

What was changed: 

I applied sort to the fetched countries array using the compareLocale on country.name.common
I was thinking of adding "sv" in localeCompare() to make Åland appear at the end of the list, but if this is for an international audience then they might be looking for Åland at the letter A. 

How to test: 

1. Open the dropdown

2. Verify that countries are sorted A–Z ( Åland appearing with countries on letter A) 


 