### PR TITLE
Fix casing on CountrySelect component and adjust heading size

### DIFF
--- a/src/components/CountrySelect.tsx
+++ b/src/components/CountrySelect.tsx
@@ -1,0 +1,52 @@
+"use client";
+import { useCountry } from "@/contexts/countryContext";
+import { Country } from "../types/country";
+import { useEffect } from "react";
+import { fetchHorrorMoviesByCountry } from "@/lib/fetchMovies"
+import { useMovies } from "@/contexts/movieContext"
+
+type Props = {
+  countries: Country[];
+};
+
+export default function CountrySelect({
+  countries,
+}: {
+  countries: Country[];
+}) {
+  const { selectedCountry, setSelectedCountry } = useCountry();
+  const { setMovies, setError, setHasSearched } = useMovies();
+
+  function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const countryCode = e.target.value;
+    const country = countries.find((country) => country.cca2 === countryCode)
+    setSelectedCountry(country ?? null);
+  }
+  useEffect(() => {
+    if (selectedCountry?.cca2) {
+      fetchHorrorMoviesByCountry(selectedCountry.cca2)
+        .then((movies) => {
+          setMovies(movies)
+          setHasSearched(true)
+        })
+        .catch((err) => setError(err.message))
+        .finally
+
+    }
+  }, [selectedCountry]);
+
+  return (
+    <select
+      value={selectedCountry?.cca2 ?? ""}
+      onChange={handleChange}
+      className="text-black text-xl md:text-2xl px-4 py-4 rounded bg-white max-w-[15rem] md:max-w-[20rem] max-h-60 overflow-y-auto"
+    >
+      <option value="">Pick a country</option>
+      {countries.map((country) => (
+        <option key={country.cca2} value={country.cca2}>
+          {country.name.common}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,7 +7,7 @@ export default async function Header() {
 
     return (
                     <header className="p-[4rem] top-[20vh] w-full">
-              <h1 className="font-bold font-serif text-3xl md:text-9xl text-warm text-center glow">HORROR WORLD</h1>
+              <h1 className="font-bold font-serif text-6xl md:text-9xl text-warm text-center glow">HORROR WORLD</h1>
               <nav className="flex justify-center p-[2rem] mt-4">
                 <CountrySelect countries={countries}></CountrySelect>
               </nav>


### PR DESCRIPTION
- Renamed countrySelect.tsx → CountrySelect.tsx to follow React convention of PascalCase component filenames.
- Adjusted the size of the main heading (<h1>) for better visual hierarchy, especially on mobile.

Maintaining consistent casing improves readability and prevents potential import issues, especially on case-sensitive file systems. Updating the heading size helps create a more polished and user-friendly UI.