### PR TITLE
refactor: fetch countries on client in Header for better performance

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,17 +1,35 @@
+"use client";
+
 import { fetchCountries } from "@/lib/fetchCountries"
 import SelectCountry from "./SelectCountry"
+import { useEffect, useState } from "react";
+import { Country } from "@/types/country";
 
-export default async function Header() {
+export default function Header() {
 
-    const countries = await fetchCountries()
+  const [countries, setCountries] = useState<Country[]>([]);
+  const [error, setError] = useState<string | null>(null);
 
-    return (
-                    <header className="p-[4rem] top-[20vh] w-full">
-              <h1 className="font-bold font-serif text-6xl md:text-9xl text-warm text-center glow">HORROR WORLD</h1>
-              <nav className="flex justify-center p-[2rem] mt-4">
-                <SelectCountry countries={countries}></SelectCountry>
-              </nav>
-            </header>
-    )
+  useEffect(() => {
+    fetchCountries()
+      .then(setCountries)
+      .catch(() => setError("Failed to load countries"));
+
+  }, [])
+
+  return (
+    <header className="p-[4rem] top-[20vh] w-full">
+      <h1 className="font-bold font-serif text-6xl md:text-9xl text-warm text-center glow">HORROR WORLD</h1>
+      <nav className="flex justify-center p-[2rem] mt-4">
+        {
+          error ? (
+            <p className="text-red-500">{error}</p>
+          ) : (
+            <SelectCountry countries={countries}></SelectCountry>
+          )
+        }
+      </nav>
+    </header>
+  )
 
 }


### PR DESCRIPTION
This PR moves the country data fetching from server-side to client-side within the Header component.

Why:
Improves perceived load time by rendering the UI before data is fetched.

Keeps the SelectCountry component dumb and focused on display logic.

Changes
Replaced server-side fetchCountries() in Header.tsx with a client-side useEffect.

Header now handles its own data state and passes countries as props to SelectCountry.