### PR TITLE
Fix/change has searched order

### DIFF
--- a/src/components/MovieList.tsx
+++ b/src/components/MovieList.tsx
@@ -11,7 +11,7 @@ export default function MovieList() {
 
     const [movies, setMovies] = useState<Movie[]>([]);
     const [loading, setLoading] = useState(false);
-    const [hasSearched, setHasSearched] = useState(false);
+    const [beginSearch, setBeginSearch] = useState(false);
     const [error, setError] = useState();
     const { selectedCountry } = useCountry();
 
@@ -20,7 +20,7 @@ export default function MovieList() {
 
         setLoading(true);
         setError(undefined);
-        setHasSearched(true)
+        setBeginSearch(true)
 
         fetchMovies(selectedCountry)
             .then((movies) => setMovies(movies))
@@ -30,7 +30,7 @@ export default function MovieList() {
             })
     }, [selectedCountry]);
 
-    if (!hasSearched) return null;
+    if (!beginSearch) return null;
     if (loading) return <p className="text-white text-xl md:text-4xl px-8 md:mt-[5%]">Loading movies...</p>;
     if (error) return <p className="text-red-500 text-xl md:text-4xl px-8 md:mt-[5%]">Something went wrong: {error}</p>;
     if (movies.length === 0) return <p className="text-white text-xl md:text-4xl px-8 md:mt-[5%]">No horror movies found from this country.</p>;

--- a/src/components/MovieList.tsx
+++ b/src/components/MovieList.tsx
@@ -20,13 +20,13 @@ export default function MovieList() {
 
         setLoading(true);
         setError(undefined);
+        setHasSearched(true)
 
         fetchMovies(selectedCountry)
             .then((movies) => setMovies(movies))
             .catch((err) => setError(err.message))
             .finally(() => {
                 setLoading(false);
-                setHasSearched(true)
             })
     }, [selectedCountry]);
 


### PR DESCRIPTION
Small fix to make loading text appear. 
Changed the name of hasSearch to beginSearch to make it more logical to put it in the right order.
Before I put it in the end when the search was over which blocked to loading logic from being able to appear until the data was already fetched and the user didn't get any feedback that data was loading.
The moment we select a country we should set beginSearch to true in order to give the user the loading text while the search is being done. 