### PR TITLE
fix: extra error handling for fetchMovies

### DIFF
--- a/src/lib/fetchMovies.ts
+++ b/src/lib/fetchMovies.ts
@@ -4,6 +4,16 @@ import { Country } from "@/types/country";
 export async function fetchMovies(selectedCountry: Country): Promise<Movie[]> {
   const res = await fetch(`/api/movies?region=${selectedCountry.cca2}`);
   if (!res.ok) throw new Error("Failed to fetch movies");
+  
   const data = await res.json();
+  
+  if (data.success === false) {
+    throw new Error(data.status_message || "Unknown TMDB error");
+  }
+
+  if (!Array.isArray(data.results)) {
+    throw new Error("API response missing 'results'");
+  }
+
   return data.results;
 }


### PR DESCRIPTION
Previously, we assumed that a fetch request returning HTTP 200 meant everything was fine.
However, TMDB can return { success: false } even with a 200 status — for example, when the API key is invalid.

This caused data.results to be undefined, which led to a crash when the component tried to read .length on it.

This PR adds:
A check for data.success === false in the fetchMovies function

A descriptive error thrown using data.status_message if available

A fallback check to ensure data.results is actually an array