### PR TITLE
fix: add fields in api request to restcountry api

### DIFF
--- a/src/lib/fetchCountries.ts
+++ b/src/lib/fetchCountries.ts
@@ -1,6 +1,6 @@
 import { Country } from "@/types/country"
 export async function fetchCountries() {
-    const res = await fetch("https://restcountries.com/v3.1/all");
+    const res = await fetch("https://restcountries.com/v3.1/all?fields=name,flags,cca2");
     if (!res.ok) throw new Error("Failed to fetch countries");
 
     const data: Country[] = await res.json();


### PR DESCRIPTION
Fix: Added fields parameter to REST Countries API request for Safari compatibility

Safari was returning a 400 Bad Request with the message:

"fields" query not specified

Unlike Chrome, Safari does not tolerate an empty fields parameter in the request to the REST Countries API. To resolve this, the request now explicitly specifies the fields name, flags, and cca2.

This ensures consistent behavior across browsers and reduces the response payload by only fetching the necessary data.