### PR TITLE
fix: adjust selectCountry styling for Safari and Chrome compatibility

### DIFF
--- a/src/components/SelectCountry.tsx
+++ b/src/components/SelectCountry.tsx
@@ -25,7 +25,7 @@ export default function SelectCountry({
         <Image
           src={selectedCountry.flags.svg}
           alt={`Flag of ${selectedCountry.name.common}`}
-          className="w-[6rem] h-auto object-cover rounded opacity-90"
+          className="w-auto h-[3.5rem] object-cover rounded opacity-90"
           height={1000}
           width={1500}
         />
@@ -33,7 +33,7 @@ export default function SelectCountry({
       <select
         value={selectedCountry?.cca2 ?? ""}
         onChange={handleChange}
-        className="w-[15rem] md:w-[20rem] text-black text-[1rem] md:text-2xl px-4 py-4 rounded bg-white h-[3rem] overflow-y-auto truncate"
+        className="w-[15rem] md:w-[20rem] text-black text-[1rem] md:text-2xl px-4 rounded bg-white h-[3.5rem] overflow-y-auto truncate"
       >
         <option value="">Pick a country</option>
         {countries.map((country) => (
@@ -46,7 +46,7 @@ export default function SelectCountry({
         <Image
           src={selectedCountry.flags.svg}
           alt={`Flag of ${selectedCountry.name.common}`}
-          className="mt-[3rem] md:mt-0 w-[7rem] md:w-[6rem] h-auto object-cover rounded opacity-90"
+          className="mt-[3rem] md:mt-0 w-[auto] h-[3.5rem] object-cover rounded opacity-90"
           height={1000}
           width={1500}
         />


### PR DESCRIPTION
Improve cross-browser styling of select element (Safari & Chrome)

Fixed an issue where text inside the <select> element was getting clipped in Chrome when trying to adjust style for safari.

Changes made:

Removed vertical padding (py) to avoid clipping in Chrome

Set a fixed height (h-[3.5rem]) to ensure correct rendering in Safari

These tweaks restore a consistent visual layout across browsers while keeping the custom dropdown arrow styling intact.

Tested in:
Safari (macOS)

Chrome (macOS)

Firefox (brief check, no regressions)